### PR TITLE
Handle API Changes

### DIFF
--- a/lib/jira/base_factory.rb
+++ b/lib/jira/base_factory.rb
@@ -38,7 +38,7 @@ module JIRA
     # The principle purpose of this class is to delegate methods to the corresponding
     # non-factory class and automatically prepend the client argument to the argument
     # list.
-    delegate_to_target_class :all, :find, :collection_path, :singular_path, :jql
+    delegate_to_target_class :all, :find, :collection_path, :singular_path, :jql, :first
 
     # This method needs special handling as it has a default argument value
     def build(attrs={})

--- a/lib/jira/resource/user.rb
+++ b/lib/jira/resource/user.rb
@@ -15,7 +15,8 @@ module JIRA
       # Cannot retrieve more than 1,000 users through the api, please see: https://jira.atlassian.com/browse/JRASERVER-65089
       def self.all(client)
         search_token = client.cloud_instance? ? "_" : "@"
-        response  = client.get("/rest/api/2/user/search?username=#{search_token}&maxResults=#{MAX_RESULTS}")
+        rest_base_path = client.cloud_instance? ? "/rest/api/3" : "/rest/api/2"
+        response  = client.get("#{rest_base_path}/user/search?username=#{search_token}&maxResults=#{MAX_RESULTS}")
         all_users = JSON.parse(response.body)
 
         all_users.flatten.uniq.map do |user|

--- a/lib/jira/resource/user.rb
+++ b/lib/jira/resource/user.rb
@@ -6,6 +6,7 @@ module JIRA
 
     class User < JIRA::Base
       MAX_RESULTS = 1000
+      MIN_RESULTS = 1
 
       def self.singular_path(client, key, prefix = '/')
         collection_path(client, prefix) + '?username=' + key
@@ -21,7 +22,17 @@ module JIRA
           client.User.build(user)
         end
       end
-    end
 
+      def self.first(client)
+        search_token = client.cloud_instance? ? "_" : "@"
+        rest_base_path = client.cloud_instance? ? "/rest/api/3" : "/rest/api/2"
+        response  = client.get("#{rest_base_path}/user/search?username=#{search_token}&maxResults=#{MIN_RESULTS}")
+        all_users = JSON.parse(response.body)
+
+        all_users.flatten.uniq.map do |user|
+          client.User.build(user)
+        end
+      end
+    end
   end
 end

--- a/spec/integration/user_spec.rb
+++ b/spec/integration/user_spec.rb
@@ -30,7 +30,7 @@ describe JIRA::Resource::User do
 
       before do
         expect(client).to receive(:get)
-                            .with("/rest/api/2/user/search?username=_&maxResults=1000") { OpenStruct.new(body: '["User1"]') }
+                            .with("/rest/api/3/user/search?username=_&maxResults=1000") { OpenStruct.new(body: '["User1"]') }
         allow(client).to receive_message_chain(:User, :build).with("users") { [] }
       end
 

--- a/spec/integration/user_spec.rb
+++ b/spec/integration/user_spec.rb
@@ -55,4 +55,38 @@ describe JIRA::Resource::User do
       end
     end
   end
+
+  describe "#first" do
+    let(:client) { JIRA::Client.new({ :username => 'foo', :password => 'bar', :auth_type => :basic, site: site }) }
+
+    context "when the client is a cloud instance" do
+      let(:site) { "https://foo.atlassian.net" }
+
+      before do
+        expect(client).to receive(:get)
+          .with("/rest/api/3/user/search?username=_&maxResults=1") { OpenStruct.new(body: '["User1"]') }
+        allow(client).to receive_message_chain(:User, :build).with("users") { [] }
+      end
+
+      it "gets users with maxResults of 1" do
+        expect(client).to receive_message_chain(:User, :build).with("User1")
+        JIRA::Resource::User.first(client)
+      end
+    end
+
+    context "when the client is not a cloud instance" do
+      let(:site) { "https://foo.onprem.com" }
+
+      before do
+        expect(client).to receive(:get)
+          .with("/rest/api/2/user/search?username=@&maxResults=1") { OpenStruct.new(body: '["User1"]') }
+        allow(client).to receive_message_chain(:User, :build).with("users") { [] }
+      end
+
+      it "gets users with maxResults of 1" do
+        expect(client).to receive_message_chain(:User, :build).with("User1")
+        JIRA::Resource::User.first(client)
+      end
+    end
+  end
 end

--- a/spec/jira/base_factory_spec.rb
+++ b/spec/jira/base_factory_spec.rb
@@ -43,4 +43,9 @@ describe JIRA::BaseFactory do
     expect(JIRA::Resource::Foo).to receive(:singular_path).with(client, 'FOO')
     subject.singular_path('FOO')
   end
+
+  it "proxies first to the target class" do
+    expect(JIRA::Resource::Foo).to receive(:first).with(client)
+    subject.first
+  end
 end


### PR DESCRIPTION
New API changes are being added that will remove name and key for on cloud users. These changes will update the api to v3 for cloud users and handle the new reliance on accountId, while keeping the same functionality for on prem users.