### PR TITLE
Search for Jira users is GDPR compliant

### DIFF
--- a/lib/jira/resource/user.rb
+++ b/lib/jira/resource/user.rb
@@ -13,8 +13,8 @@ module JIRA
 
       # Cannot retrieve more than 1,000 users through the api, please see: https://jira.atlassian.com/browse/JRASERVER-65089
       def self.all(client)
-        search_token = client.cloud_instance? ? "_" : "@"
-        response  = client.get("/rest/api/2/user/search?username=#{search_token}&maxResults=#{MAX_RESULTS}")
+        search_param = client.cloud_instance? ? "query=" : "username=@"
+        response  = client.get("/rest/api/2/user/search?#{search_param}&maxResults=#{MAX_RESULTS}")
         all_users = JSON.parse(response.body)
 
         all_users.flatten.uniq.map do |user|

--- a/spec/integration/user_spec.rb
+++ b/spec/integration/user_spec.rb
@@ -30,7 +30,7 @@ describe JIRA::Resource::User do
 
       before do
         expect(client).to receive(:get)
-                            .with("/rest/api/2/user/search?username=_&maxResults=1000") { OpenStruct.new(body: '["User1"]') }
+                            .with("/rest/api/2/user/search?query=&maxResults=1000") { OpenStruct.new(body: '["User1"]') }
         allow(client).to receive_message_chain(:User, :build).with("users") { [] }
       end
 


### PR DESCRIPTION
This is a result of changes Jira is making to the user endpoints to be GDPR compliant. 

There are two issues we addressed:
1) We could no longer query by username, since Jira is deprecating this attribute to be GDPR compliant
2) For accounts that have been migrated, the "_" search wildcard is no longer working, but passing in no wildcard works for all cloud based accounts.
