### PR TITLE
Add context_path to User.all

### DIFF
--- a/lib/jira/resource/user.rb
+++ b/lib/jira/resource/user.rb
@@ -14,7 +14,7 @@ module JIRA
       # Cannot retrieve more than 1,000 users through the api, please see: https://jira.atlassian.com/browse/JRASERVER-65089
       def self.all(client)
         search_param = client.cloud_instance? ? "query=" : "username=@"
-        response  = client.get("/rest/api/2/user/search?#{search_param}&maxResults=#{MAX_RESULTS}")
+        response  = client.get("#{client.options[:rest_base_path]}/user/search?#{search_param}&maxResults=#{MAX_RESULTS}")
         all_users = JSON.parse(response.body)
 
         all_users.flatten.uniq.map do |user|

--- a/spec/integration/user_spec.rb
+++ b/spec/integration/user_spec.rb
@@ -24,18 +24,20 @@ describe JIRA::Resource::User do
 
   describe "#all" do
     let(:client) { JIRA::Client.new({ :username => 'foo', :password => 'bar', :auth_type => :basic, site: site }) }
+    let(:base_path) { client.options[:rest_base_path] }
+
+    before do
+      allow(client).to receive_message_chain(:User, :build).with("users") { [] }
+      expect(client).to receive_message_chain(:User, :build).with("User1")
+    end
 
     context "when the client is a cloud instance" do
       let(:site) { "https://foo.atlassian.net" }
 
-      before do
-        expect(client).to receive(:get)
-                            .with("/rest/api/2/user/search?query=&maxResults=1000") { OpenStruct.new(body: '["User1"]') }
-        allow(client).to receive_message_chain(:User, :build).with("users") { [] }
-      end
-
       it "gets users with maxResults of 1000" do
-        expect(client).to receive_message_chain(:User, :build).with("User1")
+        allow(client).to receive(:get)
+          .with("#{base_path}/user/search?query=&maxResults=1000") { OpenStruct.new(body: '["User1"]') }
+
         JIRA::Resource::User.all(client)
       end
     end
@@ -44,14 +46,20 @@ describe JIRA::Resource::User do
       let(:site) { "https://foo.onprem.com" }
 
       before do
-        expect(client).to receive(:get)
-                            .with("/rest/api/2/user/search?username=@&maxResults=1000") { OpenStruct.new(body: '["User1"]') }
-        allow(client).to receive_message_chain(:User, :build).with("users") { [] }
+        allow(client).to receive(:get)
+          .with("#{base_path}/user/search?username=@&maxResults=1000") { OpenStruct.new(body: '["User1"]') }
       end
 
       it "gets users with maxResults of 1000" do
-        expect(client).to receive_message_chain(:User, :build).with("User1")
         JIRA::Resource::User.all(client)
+      end
+
+      context "when there is a context path on the client" do
+        let(:client) { JIRA::Client.new({ :username => 'foo', :password => 'bar', :auth_type => :basic, site: site, context_path: '/context_path' }) }
+
+        it "applies the context path to the url" do
+          JIRA::Resource::User.all(client)
+        end
       end
     end
   end


### PR DESCRIPTION
- It seems we accidentally removed this behavior in
854caddd814983238559abb91b2390bd80a28add.

- From what we can tell, we think we always want to include the context
  path if we have it. This will make this use /jira by default now, but
  that seems correct. From Jira's docs, it seems if your context is the
  default, you can just not use it. If you're on prem with a custom
  context path, however, you do need it.

Co-authored-by: Andy Wendt <awendt@mavenlink.com>