### PR TITLE
Paginate users

### DIFF
--- a/lib/jira/resource/user.rb
+++ b/lib/jira/resource/user.rb
@@ -1,6 +1,5 @@
 module JIRA
   module Resource
-
     class UserFactory < JIRA::BaseFactory # :nodoc:
     end
 
@@ -11,17 +10,26 @@ module JIRA
         collection_path(client, prefix) + '?username=' + key
       end
 
-      # Cannot retrieve more than 1,000 users through the api, please see: https://jira.atlassian.com/browse/JRASERVER-65089
       def self.all(client)
         search_param = client.cloud_instance? ? "query=" : "username=@"
-        response  = client.get("#{client.options[:rest_base_path]}/user/search?#{search_param}&maxResults=#{MAX_RESULTS}")
-        all_users = JSON.parse(response.body)
+        all_users = []
+        start_at = 0
 
-        all_users.flatten.uniq.map do |user|
+        loop do
+          response = client.get("#{collection_path(client)}/search?#{search_param}&maxResults=#{MAX_RESULTS}&startAt=#{start_at}")
+          parsed_response = JSON.parse(response.body)
+
+          all_users.concat(parsed_response)
+
+          break if parsed_response.count != MAX_RESULTS
+
+          start_at += MAX_RESULTS
+        end
+
+        all_users.map do |user|
           client.User.build(user)
         end
       end
     end
-
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'active_support/core_ext/hash'
 require 'rubygems'
 require 'bundler/setup'
 require 'webmock/rspec'


### PR DESCRIPTION
[The API bug limiting results to the first 1000 users has been fixed for both cloud and server.](https://jira.atlassian.com/browse/JRASERVER-65089)

This PR supports paginating all users on the account by fetching another page if the results returned match the max requested (1000) and will continue until that is not the case.