### PR TITLE
Fix security vulnerability by bumping oauth version to 0.5.6

### DIFF
--- a/jira-ruby.gemspec
+++ b/jira-ruby.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_development_dependency 'railties'
-  s.add_runtime_dependency 'oauth', '~> 0.4.7'
+  s.add_runtime_dependency 'oauth', '~> 0.5.6'
   s.add_runtime_dependency 'activesupport'
   s.add_development_dependency 'webmock', '~> 1.18.0'
   s.add_development_dependency 'rspec', '~> 3.0.0'


### PR DESCRIPTION
Konekti has a dependabot security vulnerability of High Severity for the `oauth` gem.
https://github.com/mavenlink/konekti/security/dependabot/Gemfile.lock/oauth/open

This bumps the version to the most update to date version, which includes the vulnerability fix.

As part of a push to disperse security concerns to the Dev teams, we've set up an ML project to highlight vulnerabilities that are on the organizations radar. The deliverable for this oauth fix is in https://app.mavenlink.com/workspaces/36155985/#tracker/769782055