### PR TITLE
Update cloud instance detection

### DIFF
--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -134,7 +134,7 @@ module JIRA
       JIRA::Resource::FieldFactory.new(self)
     end
 
-    def Board 
+    def Board
       JIRA::Resource::BoardFactory.new(self)
     end
 
@@ -210,7 +210,7 @@ module JIRA
     end
 
     def cloud_instance?
-      options[:site].include?("atlassian.net")
+      options[:site].include?("atlassian.net") || options[:site].include?("jira.com")
     end
 
     protected

--- a/spec/jira/client_spec.rb
+++ b/spec/jira/client_spec.rb
@@ -197,7 +197,7 @@ describe JIRA::Client do
       end
     end
 
-    context "when the site has a cloud url" do
+    context "when the site has an atlassian.net url" do
       let(:site) { "https://foo.atlassian.net" }
 
       it "returns true" do
@@ -205,7 +205,15 @@ describe JIRA::Client do
       end
     end
 
-    context "when the site does not have a cloud url (does not reference atlassian)" do
+    context "when the site has a jira.com url" do
+      let(:site) { "https://foo.jira.com" }
+
+      it "returns true" do
+        expect(client).to be_cloud_instance
+      end
+    end
+
+    context "when the site does not have a cloud url (does not reference atlassian or jira)" do
       let(:site) { "https://foo.onprem.com" }
 
       it "returns false" do


### PR DESCRIPTION
It appears sudomains on jira.com can also be cloud instances.