### PR TITLE
Keep v2 support for search

### DIFF
--- a/.github/workflows/rspec.yaml
+++ b/.github/workflows/rspec.yaml
@@ -10,11 +10,11 @@ jobs:
       image: ruby:3.0.6
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Gem cache
         id: cache-bundle
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: bundle-${{ hashFiles('**/Gemfile.lock') }}

--- a/README.rdoc
+++ b/README.rdoc
@@ -235,6 +235,7 @@ Here's the same example as a Sinatra application:
         :access_token_path  => "/plugins/servlet/oauth/access-token",
         :private_key_file   => "rsakey.pem",
         :rest_base_path     => "/rest/api/2",
+        :rest_base_path_v3  => "/rest/api/3",
         :consumer_key       => "jira-ruby-example"
       }
 

--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -50,6 +50,7 @@ module JIRA
       :site               => 'http://localhost:2990',
       :context_path       => '/jira',
       :rest_base_path     => "/rest/api/2",
+      :rest_base_path_v3 => "/rest/api/3",
       :ssl_verify_mode    => OpenSSL::SSL::VERIFY_PEER,
       :use_ssl            => true,
       :auth_type          => :oauth,

--- a/lib/jira/client.rb
+++ b/lib/jira/client.rb
@@ -61,6 +61,7 @@ module JIRA
       options = DEFAULT_OPTIONS.merge(options)
       @options = options
       @options[:rest_base_path] = @options[:context_path] + @options[:rest_base_path]
+      @options[:rest_base_path_v3] = @options[:context_path] + @options[:rest_base_path_v3]
 
       case options[:auth_type]
       when :oauth

--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -56,7 +56,7 @@ module JIRA
       end
 
       def self.jql(client, jql, options = {fields: nil, next_page_token: nil, max_results: nil, expand: nil})
-        url = client.options[:rest_base_path_v3] + "/search/jql?jql=" + CGI.escape(jql)
+        url = options[:url] || client.options[:rest_base_path_v3] + "/search/jql?jql=" + CGI.escape(jql)
 
         url << "&fields=#{options[:fields].map{ |value| CGI.escape(client.Field.name_to_id(value)) }.join(',')}" if options[:fields]
         url << "&nextPageToken=#{CGI.escape(options[:next_page_token].to_s)}" if options[:next_page_token]
@@ -66,7 +66,6 @@ module JIRA
           options[:expand] = [options[:expand]] if options[:expand].is_a?(String)
           url << "&expand=#{options[:expand].to_a.map{ |value| CGI.escape(value.to_s) }.join(',')}"
         end
-
         response = client.get(url)
         json = parse_json(response.body)
         result = {}
@@ -77,6 +76,13 @@ module JIRA
         end
         result
       end
+
+      def self.jql_v2(client, jql, options = {fields: nil, next_page_token: nil, max_results: nil, expand: nil})
+        url = client.options[:rest_base_path] + "/search/jql?jql=" + CGI.escape(jql)
+        options[url] = url
+        self.jql(client, url, jql, options)
+      end
+
 
       def editmeta
         editmeta_url = client.options[:rest_base_path] + "/#{self.class.endpoint_name}/#{key}/editmeta"

--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -59,7 +59,7 @@ module JIRA
         url = client.options[:rest_base_path_v3] + "/search/jql?jql=" + CGI.escape(jql)
 
         url << "&fields=#{options[:fields].map{ |value| CGI.escape(client.Field.name_to_id(value)) }.join(',')}" if options[:fields]
-        url << "&startAt=#{CGI.escape(options[:start_at].to_s)}" if options[:start_at]
+        url << "&nextPageToken=#{CGI.escape(options[:start_at].to_s)}" if options[:start_at]
         url << "&maxResults=#{CGI.escape(options[:max_results].to_s)}" if options[:max_results]
 
         if options[:expand]

--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -55,11 +55,11 @@ module JIRA
         end
       end
 
-      def self.jql(client, jql, options = {fields: nil, start_at: nil, max_results: nil, expand: nil})
+      def self.jql(client, jql, options = {fields: nil, nextPageToken: nil, max_results: nil, expand: nil})
         url = client.options[:rest_base_path_v3] + "/search/jql?jql=" + CGI.escape(jql)
 
         url << "&fields=#{options[:fields].map{ |value| CGI.escape(client.Field.name_to_id(value)) }.join(',')}" if options[:fields]
-        url << "&nextPageToken=#{CGI.escape(options[:start_at].to_s)}" if options[:start_at]
+        url << "&nextPageToken=#{CGI.escape(options[:nextPageToken].to_s)}" if options[:nextPageToken]
         url << "&maxResults=#{CGI.escape(options[:max_results].to_s)}" if options[:max_results]
 
         if options[:expand]
@@ -69,9 +69,13 @@ module JIRA
 
         response = client.get(url)
         json = parse_json(response.body)
-        json['issues'].map do |issue|
+        result = {}
+        result['nextPageToken'] = json[:nextPageToken] if json[:nextPageToken]
+        result['issues'] = json['issues'].map do |issue|
           client.Issue.build(issue)
+        
         end
+        result
       end
 
       def editmeta

--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -47,7 +47,7 @@ module JIRA
       has_many :remotelink, :class => JIRA::Resource::Remotelink
 
       def self.all(client)
-        url = client.options[:rest_base_path] + "/search?expand=transitions.fields"
+        url = client.options[:rest_base_path_v3] + '/search/jql?expand=transitions.fields'
         response = client.get(url)
         json = parse_json(response.body)
         json['issues'].map do |issue|
@@ -56,7 +56,7 @@ module JIRA
       end
 
       def self.jql(client, jql, options = {fields: nil, start_at: nil, max_results: nil, expand: nil})
-        url = client.options[:rest_base_path] + "/search?jql=" + CGI.escape(jql)
+        url = client.options[:rest_base_path_v3] + "/search/jql?jql=" + CGI.escape(jql)
 
         url << "&fields=#{options[:fields].map{ |value| CGI.escape(client.Field.name_to_id(value)) }.join(',')}" if options[:fields]
         url << "&startAt=#{CGI.escape(options[:start_at].to_s)}" if options[:start_at]

--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -55,11 +55,11 @@ module JIRA
         end
       end
 
-      def self.jql(client, jql, options = {fields: nil, nextPageToken: nil, max_results: nil, expand: nil})
+      def self.jql(client, jql, options = {fields: nil, next_page_token: nil, max_results: nil, expand: nil})
         url = client.options[:rest_base_path_v3] + "/search/jql?jql=" + CGI.escape(jql)
 
         url << "&fields=#{options[:fields].map{ |value| CGI.escape(client.Field.name_to_id(value)) }.join(',')}" if options[:fields]
-        url << "&nextPageToken=#{CGI.escape(options[:nextPageToken].to_s)}" if options[:nextPageToken]
+        url << "&nextPageToken=#{CGI.escape(options[:next_page_token].to_s)}" if options[:next_page_token]
         url << "&maxResults=#{CGI.escape(options[:max_results].to_s)}" if options[:max_results]
 
         if options[:expand]
@@ -70,7 +70,7 @@ module JIRA
         response = client.get(url)
         json = parse_json(response.body)
         result = {}
-        result['nextPageToken'] = json[:nextPageToken] if json[:nextPageToken]
+        result['next_page_token'] = json[:next_page_token] if json[:next_page_token] rescue nil
         result['issues'] = json['issues'].map do |issue|
           client.Issue.build(issue)
         

--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -70,7 +70,7 @@ module JIRA
         response = client.get(url)
         json = parse_json(response.body)
         result = {}
-        result['next_page_token'] = json[:next_page_token] if json[:next_page_token] rescue nil
+        result['next_page_token'] = json['nextPageToken'] if json['nextPageToken'] rescue nil
         result['issues'] = json['issues'].map do |issue|
           client.Issue.build(issue)
         

--- a/lib/jira/resource/project.rb
+++ b/lib/jira/resource/project.rb
@@ -17,7 +17,7 @@ module JIRA
 
       # Returns all the issues for this project
       def issues(options={})
-        search_url = client.options[:rest_base_path] + '/search'
+        search_url = client.options[:rest_base_path_v3] + "/search/jql"
         query_params = {:jql => "project=\"#{key}\""}
         query_params.update Base.query_params_for_search(options)
         response = client.get(url_with_query_params(search_url, query_params))

--- a/lib/jira/resource/rapidview.rb
+++ b/lib/jira/resource/rapidview.rb
@@ -32,9 +32,9 @@ module JIRA
         jql = "id IN(#{issue_ids.join(', ')})"
 
         # Filtering options
-        jql << " AND sprint IS NOT EMPTY" unless options[:include_backlog_items]
-
-        parent_issues = client.Issue.jql(jql)
+        jql << " AND sprint IS NOT EMPTY" unless options[:include_backlog_items] 
+        
+        parent_issues = client.Issue.jql(jql)["issues"]
         subtask_ids = parent_issues.map { |t| t.subtasks.map { |sub| sub['id'] } }.flatten
 
         parent_and_sub_ids = parent_issues.map(&:id) + subtask_ids

--- a/lib/jira/resource/rapidview.rb
+++ b/lib/jira/resource/rapidview.rb
@@ -33,7 +33,7 @@ module JIRA
 
         # Filtering options
         jql << " AND sprint IS NOT EMPTY" unless options[:include_backlog_items] 
-        
+
         parent_issues = client.Issue.jql(jql)["issues"]
         subtask_ids = parent_issues.map { |t| t.subtasks.map { |sub| sub['id'] } }.flatten
 

--- a/spec/integration/comment_spec.rb
+++ b/spec/integration/comment_spec.rb
@@ -42,7 +42,15 @@ describe JIRA::Resource::Comment do
     let(:expected_attributes_from_put) {
       { "id" => "10000", "body" => "new body" }
     }
-
+    before(:each) do
+      stub_request(:get, "http://foo:bar@localhost:2990/jira/rest/api/2/comment")
+        .with(headers: {
+          'Accept'=>'application/json',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'User-Agent'=>'Ruby'
+        })
+        .to_return(:status => 200, :body => '{"comments":[{"self":"http://localhost:2990/jira/rest/api/2/issue/10002/comment/10000","id":"10000","body":"This is a comment. Creative."},{"self":"http://localhost:2990/jira/rest/api/2/issue/10002/comment/10001","id":"10001","body":"Another comment."}]}', :headers => {})
+    end
     it_should_behave_like "a resource"
     it_should_behave_like "a resource with a collection GET endpoint"
     it_should_behave_like "a resource with a singular GET endpoint"

--- a/spec/integration/field_spec.rb
+++ b/spec/integration/field_spec.rb
@@ -26,7 +26,15 @@ describe JIRA::Resource::Field do
     end
 
     let(:expected_collection_length) { 2 }
-
+    before(:each) do
+      stub_request(:get, "http://foo:bar@localhost:2990/jira/rest/api/2/field")
+        .with(headers: {
+          'Accept'=>'application/json',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'User-Agent'=>'Ruby'
+        })
+        .to_return(:status => 200, :body => '[{"id":"1","name":"Description","custom":false,"orderable":true,"navigable":true,"searchable":true,"clauseNames":["description"],"schema":{"type":"string","system":"description"}},{"id":"2","name":"Summary","custom":false,"orderable":true,"navigable":true,"searchable":true,"clauseNames":["summary"],"schema":{"type":"string","system":"summary"}}]', :headers => {})
+    end
     it_should_behave_like "a resource"
     it_should_behave_like "a resource with a collection GET endpoint"
     it_should_behave_like "a resource with a singular GET endpoint"

--- a/spec/integration/issue_spec.rb
+++ b/spec/integration/issue_spec.rb
@@ -46,9 +46,25 @@ describe JIRA::Resource::Issue do
         }
       }
       before(:each) do
-        stub_request(:get, site_url + "/jira/rest/api/2/search?expand=transitions.fields").
+        stub_request(:get, site_url + "/jira/rest/api/3/search/jql?expand=transitions.fields").
                     to_return(:status => 200, :body => get_mock_response('issue.json'))
-      end
+      
+        stub_request(:get, "http://localhost:2990/rest/api/3/search/jql?expand=transitions.fields")
+          .with(headers: {
+            'Accept'=>'application/json',
+            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization'=>/OAuth .*/, # Use a regex to match any OAuth header
+            'User-Agent'=>'OAuth gem v0.5.14'
+          })
+          .to_return(status: 200, body: get_mock_response('issue.json'), headers: {})
+        stub_request(:get, "http://foo:bar@localhost:2990/rest/api/3/search/jql?expand=transitions.fields")
+                    .with(headers: {
+                    'Accept'=>'application/json',
+                    'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                    'User-Agent'=>'Ruby'
+        })
+    .to_return(status: 200, body: get_mock_response('issue.json'), headers: {})
+    end
       it_should_behave_like "a resource with a collection GET endpoint"
     end
     it_should_behave_like "a resource with a DELETE endpoint"
@@ -87,6 +103,23 @@ describe JIRA::Resource::Issue do
           "key"=>"SAMPLEPROJECT-13"
         }
       }
+      before(:each) do
+        stub_request(:get, "http://foo:bar@localhost:2990/rest/api/3/search/jql?jql=PROJECT%20=%20'SAMPLEPROJECT'")
+          .with(headers: {
+            'Accept'=>'application/json',
+            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'User-Agent'=>'Ruby'
+          })
+          .to_return(status: 200, body: get_mock_response('issue.json'), headers: {})
+        stub_request(:get, "http://localhost:2990/rest/api/3/search/jql?jql=PROJECT%20=%20'SAMPLEPROJECT'")
+          .with(headers: {
+            'Accept'=>'application/json',
+            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization'=>/OAuth .*/, # Use a regex to match any OAuth header
+            'User-Agent'=>'OAuth gem v0.5.14'
+    })
+  .to_return(status: 200, body: get_mock_response('issue.json'), headers: {})
+        end
       it_should_behave_like "a resource with JQL inputs and a collection GET endpoint"
     end
 

--- a/spec/integration/issue_spec.rb
+++ b/spec/integration/issue_spec.rb
@@ -48,31 +48,15 @@ describe JIRA::Resource::Issue do
       before(:each) do
         stub_request(:get, site_url + "/jira/rest/api/3/search/jql?expand=transitions.fields").
                     to_return(:status => 200, :body => get_mock_response('issue.json'))
-      
-        stub_request(:get, "http://localhost:2990/rest/api/3/search/jql?expand=transitions.fields")
-          .with(headers: {
-            'Accept'=>'application/json',
-            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'Authorization'=>/OAuth .*/, # Use a regex to match any OAuth header
-            'User-Agent'=>'OAuth gem v0.5.14'
-          })
-          .to_return(status: 200, body: get_mock_response('issue.json'), headers: {})
-        stub_request(:get, "http://foo:bar@localhost:2990/rest/api/3/search/jql?expand=transitions.fields")
-                    .with(headers: {
-                    'Accept'=>'application/json',
-                    'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-                    'User-Agent'=>'Ruby'
-        })
-    .to_return(status: 200, body: get_mock_response('issue.json'), headers: {})
-    end
+      end
       it_should_behave_like "a resource with a collection GET endpoint"
     end
     it_should_behave_like "a resource with a DELETE endpoint"
     it_should_behave_like "a resource with a POST endpoint"
     it_should_behave_like "a resource with a PUT endpoint"
     it_should_behave_like "a resource with a PUT endpoint that rejects invalid fields"
-
     describe "errors" do
+      
       before(:each) do
         stub_request(:get,
                     site_url + "/jira/rest/api/2/issue/10002").
@@ -103,22 +87,24 @@ describe JIRA::Resource::Issue do
           "key"=>"SAMPLEPROJECT-13"
         }
       }
+      
       before(:each) do
-        stub_request(:get, "http://foo:bar@localhost:2990/rest/api/3/search/jql?jql=PROJECT%20=%20'SAMPLEPROJECT'")
+        
+        stub_request(:get, "http://foo:bar@localhost:2990/jira/rest/api/3/search/jql?jql=PROJECT%20=%20'SAMPLEPROJECT'")
           .with(headers: {
             'Accept'=>'application/json',
             'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
             'User-Agent'=>'Ruby'
           })
           .to_return(status: 200, body: get_mock_response('issue.json'), headers: {})
-        stub_request(:get, "http://localhost:2990/rest/api/3/search/jql?jql=PROJECT%20=%20'SAMPLEPROJECT'")
+        stub_request(:get, site_url + "/jira/rest/api/3/search/jql?jql=PROJECT%20=%20'SAMPLEPROJECT'")
           .with(headers: {
             'Accept'=>'application/json',
             'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
             'Authorization'=>/OAuth .*/, # Use a regex to match any OAuth header
             'User-Agent'=>'OAuth gem v0.5.14'
     })
-  .to_return(status: 200, body: get_mock_response('issue.json'), headers: {})
+          .to_return(status: 200, body: get_mock_response('issue.json'), headers: {})
         end
       it_should_behave_like "a resource with JQL inputs and a collection GET endpoint"
     end

--- a/spec/integration/issuelinktype_spec.rb
+++ b/spec/integration/issuelinktype_spec.rb
@@ -2,6 +2,20 @@ require 'spec_helper'
 
 describe JIRA::Resource::Issuelinktype do
 
+  before(:each) do
+    stub_request(:get, "http://foo:bar@localhost:2990/jira/rest/api/2/issueLinkType")
+      .with(headers: {
+        'Accept'=>'application/json',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'User-Agent'=>'Ruby'
+      })
+      .to_return(
+        :status => 200,
+        :body => '{"issueLinkTypes":[{"id":"10000","self":"http://localhost:2990/jira/rest/api/2/issueLinkType/10000","name":"Blocks","inward":"is blocked by","outward":"blocks"},{"id":"10001","self":"http://localhost:2990/jira/rest/api/2/issueLinkType/10001","name":"Relates","inward":"relates to","outward":"relates to"},{"id":"10002","self":"http://localhost:2990/jira/rest/api/2/issueLinkType/10002","name":"Duplicates","inward":"is duplicated by","outward":"duplicates"}]}',
+        :headers => {}
+      )
+  end
+
   with_each_client do |site_url, client|
     let(:client) { client }
     let(:site_url) { site_url }

--- a/spec/integration/issuetype_spec.rb
+++ b/spec/integration/issuetype_spec.rb
@@ -18,6 +18,16 @@ describe JIRA::Resource::Issuetype do
 
     let(:expected_collection_length) { 5 }
 
+    before(:each) do
+      stub_request(:get, "http://foo:bar@localhost:2990/jira/rest/api/2/issuetype")
+        .with(headers: {
+          'Accept'=>'application/json',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'User-Agent'=>'Ruby'
+        })
+        .to_return(:status => 200, :body => '[{"self":"http://localhost:2990/jira/rest/api/2/issuetype/5","id":"5","name":"Sub-task"},{"self":"http://localhost:2990/jira/rest/api/2/issuetype/1","id":"1","name":"Bug"},{"self":"http://localhost:2990/jira/rest/api/2/issuetype/2","id":"2","name":"Task"},{"self":"http://localhost:2990/jira/rest/api/2/issuetype/3","id":"3","name":"Story"},{"self":"http://localhost:2990/jira/rest/api/2/issuetype/4","id":"4","name":"Epic"}]', :headers => {})
+    end
+
     it_should_behave_like "a resource"
     it_should_behave_like "a resource with a collection GET endpoint"
     it_should_behave_like "a resource with a singular GET endpoint"

--- a/spec/integration/priority_spec.rb
+++ b/spec/integration/priority_spec.rb
@@ -2,6 +2,16 @@ require 'spec_helper'
 
 describe JIRA::Resource::Priority do
 
+  before(:each) do
+    stub_request(:get, "http://foo:bar@localhost:2990/jira/rest/api/2/priority")
+      .with(headers: {
+        'Accept'=>'application/json',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'User-Agent'=>'Ruby'
+      })
+      .to_return(:status => 200, :body => '[{"self":"http://localhost:2990/jira/rest/api/2/priority/1","id":"1","name":"Blocker"},{"self":"http://localhost:2990/jira/rest/api/2/priority/2","id":"2","name":"Critical"},{"self":"http://localhost:2990/jira/rest/api/2/priority/3","id":"3","name":"Major"},{"self":"http://localhost:2990/jira/rest/api/2/priority/4","id":"4","name":"Minor"},{"self":"http://localhost:2990/jira/rest/api/2/priority/5","id":"5","name":"Trivial"}]', :headers => {})
+  end
+
   with_each_client do |site_url, client|
     let(:client) { client }
     let(:site_url) { site_url }

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -52,5 +52,15 @@ describe JIRA::Resource::Project do
       end
 
     end
+
+    before(:each) do
+      stub_request(:get, "http://foo:bar@localhost:2990/jira/rest/api/2/project")
+        .with(headers: {
+          'Accept'=>'application/json',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'User-Agent'=>'Ruby'
+        })
+        .to_return(:status => 200, :body => get_mock_from_path(:get), :headers => {})
+    end
   end
 end

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -26,7 +26,7 @@ describe JIRA::Resource::Project do
     describe "issues" do
 
       it "returns all the issues" do
-        stub_request(:get, site_url + "/jira/rest/api/2/search?jql=project=\"SAMPLEPROJECT\"").
+        stub_request(:get, site_url + "/rest/api/3/search?jql=project=\"SAMPLEPROJECT\"").
           to_return(:status => 200, :body => get_mock_response('project/SAMPLEPROJECT.issues.json'))
         subject = client.Project.build('key' => key)
         issues = subject.issues

--- a/spec/integration/rapidview_spec.rb
+++ b/spec/integration/rapidview_spec.rb
@@ -81,9 +81,8 @@ describe JIRA::Resource::RapidView do
 
         subject = client.RapidView.build('id' => 1)
         issues = subject.issues
-        expect(issues.length).to eq(2)
-
-        issues.each do |issue|
+        expect(issues["issues"].length).to eq(2)
+        issues["issues"].each do |issue|
           expect(issue.class).to eq(JIRA::Resource::Issue)
           expect(issue.expanded?).to be_falsey
         end

--- a/spec/integration/rapidview_spec.rb
+++ b/spec/integration/rapidview_spec.rb
@@ -30,6 +30,7 @@ describe JIRA::Resource::RapidView do
       before(:each) do
         stub_request(:get, site_url + '/jira/rest/greenhopper/1.0/rapidview').
         to_return(:status => 200, :body => get_mock_response('rapidview.json'))
+
       end
       it_should_behave_like 'a resource with a collection GET endpoint'
     end
@@ -44,10 +45,27 @@ describe JIRA::Resource::RapidView do
           :status => 200,
           :body => get_mock_response('rapidview/SAMPLEPROJECT.issues.json')
         )
-
+        stub_request(:get, "http://localhost:2990/rest/api/3/search/jql?jql=id%20IN(10000,%2010001)%20AND%20sprint%20IS%20NOT%20EMPTY")
+        .with(headers: {
+        'Accept'=>'application/json',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Authorization'=>/OAuth .*/,
+        'User-Agent'=>'OAuth gem v0.5.14'
+        })
+      .to_return(status: 200, body: get_mock_response('rapidview/SAMPLEPROJECT.issues.full.json'), headers: {})
         stub_request(
           :get,
-          site_url + '/jira/rest/api/2/search?jql=id IN(10000, 10001)%20AND%20sprint%20IS%20NOT%20EMPTY'
+          "http://localhost:2990/rest/api/3/search/jql?jql=id%20IN(10001,%2010000)"
+        ).with(headers: {
+          'Accept'=>'application/json',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Authorization'=>/OAuth .*/,
+          'User-Agent'=>'OAuth gem v0.5.14'
+        })
+        .to_return(status: 200, body: get_mock_response('rapidview/SAMPLEPROJECT.issues.full.json'), headers: {})
+        stub_request(
+          :get,
+          'http://foo:bar@localhost:2990' + '/rest/api/3/search/jql?jql=id IN(10000, 10001)%20AND%20sprint%20IS%20NOT%20EMPTY'
         ).to_return(
           :status => 200,
           :body => get_mock_response('rapidview/SAMPLEPROJECT.issues.full.json')
@@ -55,7 +73,7 @@ describe JIRA::Resource::RapidView do
 
         stub_request(
           :get,
-          site_url + '/jira/rest/api/2/search?jql=id IN(10001, 10000)'
+          'http://foo:bar@localhost:2990' + '/rest/api/3/search/jql?jql=id IN(10001, 10000)'
         ).to_return(
           :status => 200,
           :body => get_mock_response('rapidview/SAMPLEPROJECT.issues.full.json')

--- a/spec/integration/rapidview_spec.rb
+++ b/spec/integration/rapidview_spec.rb
@@ -45,7 +45,7 @@ describe JIRA::Resource::RapidView do
           :status => 200,
           :body => get_mock_response('rapidview/SAMPLEPROJECT.issues.json')
         )
-        stub_request(:get, "http://localhost:2990/rest/api/3/search/jql?jql=id%20IN(10000,%2010001)%20AND%20sprint%20IS%20NOT%20EMPTY")
+        stub_request(:get, "http://localhost:2990/jira/rest/api/3/search/jql?jql=id%20IN(10000,%2010001)%20AND%20sprint%20IS%20NOT%20EMPTY")
         .with(headers: {
         'Accept'=>'application/json',
         'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
@@ -55,7 +55,7 @@ describe JIRA::Resource::RapidView do
       .to_return(status: 200, body: get_mock_response('rapidview/SAMPLEPROJECT.issues.full.json'), headers: {})
         stub_request(
           :get,
-          "http://localhost:2990/rest/api/3/search/jql?jql=id%20IN(10001,%2010000)"
+          "http://localhost:2990/jira/rest/api/3/search/jql?jql=id%20IN(10001,%2010000)"
         ).with(headers: {
           'Accept'=>'application/json',
           'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
@@ -65,7 +65,7 @@ describe JIRA::Resource::RapidView do
         .to_return(status: 200, body: get_mock_response('rapidview/SAMPLEPROJECT.issues.full.json'), headers: {})
         stub_request(
           :get,
-          'http://foo:bar@localhost:2990' + '/rest/api/3/search/jql?jql=id IN(10000, 10001)%20AND%20sprint%20IS%20NOT%20EMPTY'
+          'http://foo:bar@localhost:2990' + '/jira/rest/api/3/search/jql?jql=id IN(10000, 10001)%20AND%20sprint%20IS%20NOT%20EMPTY'
         ).to_return(
           :status => 200,
           :body => get_mock_response('rapidview/SAMPLEPROJECT.issues.full.json')
@@ -73,7 +73,7 @@ describe JIRA::Resource::RapidView do
 
         stub_request(
           :get,
-          'http://foo:bar@localhost:2990' + '/rest/api/3/search/jql?jql=id IN(10001, 10000)'
+          'http://foo:bar@localhost:2990' + '/jira/rest/api/3/search/jql?jql=id IN(10001, 10000)'
         ).to_return(
           :status => 200,
           :body => get_mock_response('rapidview/SAMPLEPROJECT.issues.full.json')

--- a/spec/integration/status_spec.rb
+++ b/spec/integration/status_spec.rb
@@ -2,6 +2,16 @@ require 'spec_helper'
 
 describe JIRA::Resource::Status do
 
+  before(:each) do
+    stub_request(:get, "http://foo:bar@localhost:2990/jira/rest/api/2/status")
+      .with(headers: {
+        'Accept'=>'application/json',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'User-Agent'=>'Ruby'
+      })
+      .to_return(:status => 200, :body => '[{"self":"http://localhost:2990/jira/rest/api/2/status/1","id":"1","name":"Open"},{"self":"http://localhost:2990/jira/rest/api/2/status/2","id":"2","name":"In Progress"},{"self":"http://localhost:2990/jira/rest/api/2/status/3","id":"3","name":"Resolved"},{"self":"http://localhost:2990/jira/rest/api/2/status/4","id":"4","name":"Closed"},{"self":"http://localhost:2990/jira/rest/api/2/status/5","id":"5","name":"Reopened"}]', :headers => {})
+  end
+
   with_each_client do |site_url, client|
     let(:client) { client }
     let(:site_url) { site_url }

--- a/spec/integration/worklog_spec.rb
+++ b/spec/integration/worklog_spec.rb
@@ -2,6 +2,16 @@ require 'spec_helper'
 
 describe JIRA::Resource::Worklog do
 
+  before(:each) do
+    stub_request(:get, "http://foo:bar@localhost:2990/jira/rest/api/2/worklog")
+      .with(headers: {
+        'Accept'=>'application/json',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'User-Agent'=>'Ruby'
+      })
+      .to_return(:status => 200, :body => '{"worklogs":[{"self":"http://localhost:2990/jira/rest/api/2/issue/10002/worklog/10000","id":"10000","comment":"Some epic work."},{"self":"http://localhost:2990/jira/rest/api/2/issue/10002/worklog/10001","id":"10001","comment":"Another worklog."},{"self":"http://localhost:2990/jira/rest/api/2/issue/10002/worklog/10002","id":"10002","comment":"More work."}]}', :headers => {})
+  end
+
 
   with_each_client do |site_url, client|
     let(:client) { client }

--- a/spec/jira/resource/filter_spec.rb
+++ b/spec/jira/resource/filter_spec.rb
@@ -28,7 +28,7 @@ describe JIRA::Resource::Filter do
       :owner => jira_user,
       :jql => '"Git Repository" ~ jira-ruby AND status = Resolved',
       :viewUrl => 'https://localhost/secure/IssueNavigator.jspa?mode=hide&requestId=42',
-      :searchUrl => 'https://localhost/rest/api/2/search?jql=%22Git+Repository%22+~+jira-ruby+AND+status+%3D+Resolved',
+      :searchUrl => 'https://localhost/rest/api/3/search/jql?jql=%22Git+Repository%22+~+jira-ruby+AND+status+%3D+Resolved',
       :favourite => false,
       :sharePermissions => [
         {
@@ -84,9 +84,9 @@ describe JIRA::Resource::Filter do
 
   it "returns issues" do
     expect(filter).to be_present
-    allow(client).to receive(:options).and_return({ :rest_base_path => 'localhost' })
+    allow(client).to receive(:options).and_return({ :rest_base_path => 'localhost', :rest_base_path_v3 => 'localhost' })
     expect(client).to receive(:get).
-      with("localhost/search?jql=#{CGI.escape(filter.jql)}").
+      with("localhost/search/jql?jql=#{CGI.escape(filter.jql)}").
       and_return(issue_jql_response)
     issues = filter.issues
     expect(issues).to be_an(Array)

--- a/spec/jira/resource/filter_spec.rb
+++ b/spec/jira/resource/filter_spec.rb
@@ -66,7 +66,7 @@ describe JIRA::Resource::Filter do
   end
   let(:jql_attrs) do
     {
-      :startAt => 0,
+      :nextPageToken => 0,
       :maxResults => 50,
       :total => 2,
       :issues => [jql_issue]
@@ -89,9 +89,9 @@ describe JIRA::Resource::Filter do
       with("localhost/search/jql?jql=#{CGI.escape(filter.jql)}").
       and_return(issue_jql_response)
     issues = filter.issues
-    expect(issues).to be_an(Array)
-    expect(issues.size).to eql(1)
+    expect(issues).to be_an(Hash)
+    expect(issues["issues"].size).to eql(1)
     expected_issue = client.Issue.build(JSON.parse(jql_issue.to_json))
-    expect(issues.first.attrs).to eql(expected_issue.attrs)
+    expect(issues["issues"].first.attrs).to eql(expected_issue.attrs)
   end
 end

--- a/spec/jira/resource/issue_spec.rb
+++ b/spec/jira/resource/issue_spec.rb
@@ -6,7 +6,7 @@ describe JIRA::Resource::Issue do
   end
 
   let(:client) do
-    client = double(options: {rest_base_path: '/jira/rest/api/2'}  )
+    client = double(options: {rest_base_path: '/jira/rest/api/2', rest_base_path_v3: '/jira/rest/api/3'})
     allow(client).to receive(:Field).and_return(JIRA::Resource::FieldFactory.new(client))
     allow(client).to receive(:cache).and_return(OpenStruct.new)
     client
@@ -40,7 +40,7 @@ describe JIRA::Resource::Issue do
     issue = double()
 
     allow(response).to receive(:body).and_return('{"issues":[{"id":"1","summary":"Bugs Everywhere"}]}')
-    expect(client).to receive(:get).with('/jira/rest/api/2/search?expand=transitions.fields').
+    expect(client).to receive(:get).with('/jira/rest/api/3/search/jql?expand=transitions.fields').
       and_return(response)
     expect(client).to receive(:Issue).and_return(issue)
     expect(issue).to receive(:build).with({"id"=>"1","summary"=>"Bugs Everywhere"})
@@ -69,7 +69,7 @@ describe JIRA::Resource::Issue do
     issue = double()
 
     allow(response).to receive(:body).and_return('{"issues": {"key":"foo"}}')
-    expect(client).to receive(:get).with('/jira/rest/api/2/search?jql=foo+bar').
+    expect(client).to receive(:get).with('/jira/rest/api/3/search/jql?jql=foo+bar').
       and_return(response)
     expect(client).to receive(:Issue).and_return(issue)
     expect(issue).to receive(:build).with(["key", "foo"]).and_return('')
@@ -83,7 +83,7 @@ describe JIRA::Resource::Issue do
 
     allow(response).to receive(:body).and_return('{"issues": {"key":"foo"}}')
     expect(client).to receive(:get)
-      .with('/jira/rest/api/2/search?jql=foo+bar&fields=foo,bar')
+      .with('/jira/rest/api/3/search/jql?jql=foo+bar&fields=foo,bar')
       .and_return(response)
     expect(client).to receive(:Issue).and_return(issue)
     expect(issue).to receive(:build).with(["key", "foo"]).and_return('')
@@ -97,7 +97,7 @@ describe JIRA::Resource::Issue do
 
     allow(response).to receive(:body).and_return('{"issues": {"key":"foo"}}')
     expect(client).to receive(:get)
-      .with('/jira/rest/api/2/search?jql=foo+bar&startAt=1&maxResults=3')
+      .with('/jira/rest/api/3/search/jql?jql=foo+bar&startAt=1&maxResults=3')
       .and_return(response)
     expect(client).to receive(:Issue).and_return(issue)
     expect(issue).to receive(:build).with(["key", "foo"]).and_return('')
@@ -111,7 +111,7 @@ describe JIRA::Resource::Issue do
 
     allow(response).to receive(:body).and_return('{"issues": {"key":"foo"}}')
     expect(client).to receive(:get)
-      .with('/jira/rest/api/2/search?jql=foo+bar&expand=transitions')
+      .with('/jira/rest/api/3/search/jql?jql=foo+bar&expand=transitions')
       .and_return(response)
     expect(client).to receive(:Issue).and_return(issue)
     expect(issue).to receive(:build).with(["key", "foo"]).and_return('')
@@ -125,7 +125,7 @@ describe JIRA::Resource::Issue do
 
     allow(response).to receive(:body).and_return('{"issues": {"key":"foo"}}')
     expect(client).to receive(:get)
-      .with('/jira/rest/api/2/search?jql=foo+bar&expand=transitions')
+      .with('/jira/rest/api/3/search/jql?jql=foo+bar&expand=transitions')
       .and_return(response)
     expect(client).to receive(:Issue).and_return(issue)
     expect(issue).to receive(:build).with(["key", "foo"]).and_return('')
@@ -207,6 +207,18 @@ describe JIRA::Resource::Issue do
 
       expect(subject).to have_many(:worklogs, JIRA::Resource::Worklog)
       expect(subject.worklogs.length).to eq(2)
+    end
+  end
+
+  describe "GET /rest/api/3/search/jql" do
+    before(:each) do
+      stub_request(:get, "http://foo:bar@localhost:2990/rest/api/3/search/jql?jql=PROJECT%20=%20'SAMPLEPROJECT'")
+        .with(headers: {
+          'Accept'=>'application/json',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'User-Agent'=>'Ruby'
+        })
+        .to_return(status: 200, body: get_mock_response('issue.json'), headers: {})
     end
   end
 end

--- a/spec/jira/resource/issue_spec.rb
+++ b/spec/jira/resource/issue_spec.rb
@@ -97,7 +97,7 @@ describe JIRA::Resource::Issue do
 
     allow(response).to receive(:body).and_return('{"issues": {"key":"foo"}}')
     expect(client).to receive(:get)
-      .with('/jira/rest/api/3/search/jql?jql=foo+bar&startAt=1&maxResults=3')
+      .with('/jira/rest/api/3/search/jql?jql=foo+bar&nextPageToken=1&maxResults=3')
       .and_return(response)
     expect(client).to receive(:Issue).and_return(issue)
     expect(issue).to receive(:build).with(["key", "foo"]).and_return('')

--- a/spec/jira/resource/issue_spec.rb
+++ b/spec/jira/resource/issue_spec.rb
@@ -74,7 +74,7 @@ describe JIRA::Resource::Issue do
     expect(client).to receive(:Issue).and_return(issue)
     expect(issue).to receive(:build).with(["key", "foo"]).and_return('')
 
-    expect(JIRA::Resource::Issue.jql(client,'foo bar')).to eq([''])
+    expect(JIRA::Resource::Issue.jql(client,'foo bar')).to eq({"issues" => [""]})
   end
 
   it "should search an issue with a jql query string and fields" do
@@ -88,7 +88,7 @@ describe JIRA::Resource::Issue do
     expect(client).to receive(:Issue).and_return(issue)
     expect(issue).to receive(:build).with(["key", "foo"]).and_return('')
 
-    expect(JIRA::Resource::Issue.jql(client, 'foo bar', fields: ['foo','bar'])).to eq([''])
+    expect(JIRA::Resource::Issue.jql(client, 'foo bar', fields: ['foo','bar'])).to eq({"issues" => [""]})
   end
 
   it "should search an issue with a jql query string, start at, and maxResults" do
@@ -97,12 +97,12 @@ describe JIRA::Resource::Issue do
 
     allow(response).to receive(:body).and_return('{"issues": {"key":"foo"}}')
     expect(client).to receive(:get)
-      .with('/jira/rest/api/3/search/jql?jql=foo+bar&nextPageToken=1&maxResults=3')
+      .with('/jira/rest/api/3/search/jql?jql=foo+bar&maxResults=3')
       .and_return(response)
     expect(client).to receive(:Issue).and_return(issue)
     expect(issue).to receive(:build).with(["key", "foo"]).and_return('')
 
-    expect(JIRA::Resource::Issue.jql(client,'foo bar', start_at: 1, max_results: 3)).to eq([''])
+    expect(JIRA::Resource::Issue.jql(client,'foo bar', start_at: 1, max_results: 3)).to eq({"issues" => [""]})
   end
 
   it "should search an issue with a jql query string and string expand" do
@@ -116,7 +116,7 @@ describe JIRA::Resource::Issue do
     expect(client).to receive(:Issue).and_return(issue)
     expect(issue).to receive(:build).with(["key", "foo"]).and_return('')
 
-    expect(JIRA::Resource::Issue.jql(client,'foo bar', expand: 'transitions')).to eq([''])
+    expect(JIRA::Resource::Issue.jql(client,'foo bar', expand: 'transitions')).to eq("issues" =>[""])
   end
 
   it "should search an issue with a jql query string and array expand" do
@@ -130,7 +130,7 @@ describe JIRA::Resource::Issue do
     expect(client).to receive(:Issue).and_return(issue)
     expect(issue).to receive(:build).with(["key", "foo"]).and_return('')
 
-    expect(JIRA::Resource::Issue.jql(client,'foo bar', expand: %w(transitions))).to eq([''])
+    expect(JIRA::Resource::Issue.jql(client,'foo bar', expand: %w(transitions))).to eq("issues" =>[""])
   end
 
   it 'should return meta data available for editing an issue' do

--- a/spec/jira/resource/project_spec.rb
+++ b/spec/jira/resource/project_spec.rb
@@ -42,7 +42,7 @@ describe JIRA::Resource::Project do
       issue_factory = double("issue factory")
 
       expect(client).to receive(:get)
-        .with('/jira/rest/api/2/search?jql=project%3D%22test%22')
+        .with('/jira/rest/api/3/search/jql?jql=project%3D%22test%22')
         .and_return(response)
       expect(client).to receive(:Issue).and_return(issue_factory)
       expect(issue_factory).to receive(:build)
@@ -58,7 +58,7 @@ describe JIRA::Resource::Project do
         issue_factory = double("issue factory")
 
         expect(client).to receive(:get)
-          .with('/jira/rest/api/2/search?jql=project%3D%22test%22&expand=changelog&startAt=1&maxResults=100')
+          .with('/jira/rest/api/3/search/jql?jql=project%3D%22test%22&expand=changelog&startAt=1&maxResults=100')
           .and_return(response)
         expect(client).to receive(:Issue).and_return(issue_factory)
         expect(issue_factory).to receive(:build)
@@ -66,5 +66,15 @@ describe JIRA::Resource::Project do
         subject.issues({expand:'changelog', startAt:1, maxResults:100})
       end
     end
+  end
+
+  before(:each) do
+    stub_request(:get, "http://foo:bar@localhost:2990/rest/api/3/search/jql?jql=PROJECT%20=%20'SAMPLEPROJECT'")
+      .with(headers: {
+        'Accept'=>'application/json',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'User-Agent'=>'Ruby'
+      })
+      .to_return(status: 200, body: get_mock_response('issue.json'), headers: {})
   end
 end

--- a/spec/jira/resource/project_spec.rb
+++ b/spec/jira/resource/project_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe JIRA::Resource::Project do
 
   let(:client) { double("client", :options => {
-                          :rest_base_path => '/jira/rest/api/2'
+                          :rest_base_path => '/jira/rest/api/2',
+                          :rest_base_path_v3 => '/jira/rest/api/3'
                         })
   }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,20 +1,5 @@
 RSpec.configure do |config|
   config.before(:each) do
-    stub_request(:get, "http://foo:bar@localhost:2990/jira/rest/api/2/field")
-      .with(headers: {
-        'Accept'=>'application/json',
-        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'User-Agent'=>'Ruby'
-      })
-      .to_return(:status => 200, :body => '[{"id":"1","name":"Description","custom":false,"orderable":true,"navigable":true,"searchable":true,"clauseNames":["description"],"schema":{"type":"string","system":"description"}},{"id":"2","name":"Summary","custom":false,"orderable":true,"navigable":true,"searchable":true,"clauseNames":["summary"],"schema":{"type":"string","system":"summary"}}]', :headers => {})
-    stub_request(:get, "http://foo:bar@localhost:2990/jira/rest/api/2/project")
-      .with(headers: {
-        'Accept'=>'application/json',
-        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'User-Agent'=>'Ruby'
-      })
-      .to_return(:status => 200, :body => '', :headers => {})
-
     stub_request(:get, "http://foo:bar@localhost:2990/rest/api/3/search/jql?jql=project=%22SAMPLEPROJECT%22")
       .with(headers: {
         'Accept'=>'application/json',
@@ -31,14 +16,6 @@ RSpec.configure do |config|
         'User-Agent'=>/OAuth gem.*/
       })
       .to_return(:status => 200, :body => '{ "issues": [ {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} ] }', :headers => {})
-
-    stub_request(:get, "http://foo:bar@localhost:2990/jira/rest/api/2/comment")
-      .with(headers: {
-        'Accept'=>'application/json',
-        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'User-Agent'=>'Ruby'
-      })
-      .to_return(:status => 200, :body => '{"comments":[{"self":"http://localhost:2990/jira/rest/api/2/issue/10002/comment/10000","id":"10000","body":"This is a comment. Creative."},{"self":"http://localhost:2990/jira/rest/api/2/issue/10002/comment/10001","id":"10001","body":"Another comment."}]}', :headers => {})
   end
 end
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,46 @@
+RSpec.configure do |config|
+  config.before(:each) do
+    stub_request(:get, "http://foo:bar@localhost:2990/jira/rest/api/2/field")
+      .with(headers: {
+        'Accept'=>'application/json',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'User-Agent'=>'Ruby'
+      })
+      .to_return(:status => 200, :body => '[{"id":"1","name":"Description","custom":false,"orderable":true,"navigable":true,"searchable":true,"clauseNames":["description"],"schema":{"type":"string","system":"description"}},{"id":"2","name":"Summary","custom":false,"orderable":true,"navigable":true,"searchable":true,"clauseNames":["summary"],"schema":{"type":"string","system":"summary"}}]', :headers => {})
+    stub_request(:get, "http://foo:bar@localhost:2990/jira/rest/api/2/project")
+      .with(headers: {
+        'Accept'=>'application/json',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'User-Agent'=>'Ruby'
+      })
+      .to_return(:status => 200, :body => '', :headers => {})
+
+    stub_request(:get, "http://foo:bar@localhost:2990/rest/api/3/search/jql?jql=project=%22SAMPLEPROJECT%22")
+      .with(headers: {
+        'Accept'=>'application/json',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'User-Agent'=>'Ruby'
+      })
+      .to_return(:status => 200, :body => '{ "issues": [ {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} ] }', :headers => {})
+
+    stub_request(:get, "http://localhost:2990/rest/api/3/search/jql?jql=project=%22SAMPLEPROJECT%22")
+      .with(headers: {
+        'Accept'=>'application/json',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Authorization'=>/OAuth .*/,
+        'User-Agent'=>/OAuth gem.*/
+      })
+      .to_return(:status => 200, :body => '{ "issues": [ {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} ] }', :headers => {})
+
+    stub_request(:get, "http://foo:bar@localhost:2990/jira/rest/api/2/comment")
+      .with(headers: {
+        'Accept'=>'application/json',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'User-Agent'=>'Ruby'
+      })
+      .to_return(:status => 200, :body => '{"comments":[{"self":"http://localhost:2990/jira/rest/api/2/issue/10002/comment/10000","id":"10000","body":"This is a comment. Creative."},{"self":"http://localhost:2990/jira/rest/api/2/issue/10002/comment/10001","id":"10001","body":"Another comment."}]}', :headers => {})
+  end
+end
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'active_support/core_ext/hash'
 require 'rubygems'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 RSpec.configure do |config|
   config.before(:each) do
-    stub_request(:get, "http://foo:bar@localhost:2990/rest/api/3/search/jql?jql=project=%22SAMPLEPROJECT%22")
+    stub_request(:get, "http://foo:bar@localhost:2990/jira/rest/api/3/search/jql?jql=project=%22SAMPLEPROJECT%22")
       .with(headers: {
         'Accept'=>'application/json',
         'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
@@ -8,7 +8,7 @@ RSpec.configure do |config|
       })
       .to_return(:status => 200, :body => '{ "issues": [ {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} ] }', :headers => {})
 
-    stub_request(:get, "http://localhost:2990/rest/api/3/search/jql?jql=project=%22SAMPLEPROJECT%22")
+    stub_request(:get, "http://localhost:2990/jira/rest/api/3/search/jql?jql=project=%22SAMPLEPROJECT%22")
       .with(headers: {
         'Accept'=>'application/json',
         'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',

--- a/spec/support/shared_examples/integration.rb
+++ b/spec/support/shared_examples/integration.rb
@@ -70,8 +70,8 @@ end
 shared_examples "a resource with a collection GET endpoint" do
 
   it "should get the collection" do
-    stub_request(:get, site_url + described_class.collection_path(client)).
-                 to_return(:status => 200, :body => get_mock_from_path(:get))
+      stub_request(:get, described_class.collection_path(client)).
+        to_return(:status => 200, :body => get_mock_from_path(:get))
     collection = build_receiver.all
 
     expect(collection.length).to eq(expected_collection_length)

--- a/spec/support/shared_examples/integration.rb
+++ b/spec/support/shared_examples/integration.rb
@@ -70,8 +70,8 @@ end
 shared_examples "a resource with a collection GET endpoint" do
 
   it "should get the collection" do
-      stub_request(:get, described_class.collection_path(client)).
-        to_return(:status => 200, :body => get_mock_from_path(:get))
+    stub_request(:get, described_class.collection_path(client)).
+      to_return(:status => 200, :body => get_mock_from_path(:get))
     collection = build_receiver.all
 
     expect(collection.length).to eq(expected_collection_length)

--- a/spec/support/shared_examples/integration.rb
+++ b/spec/support/shared_examples/integration.rb
@@ -86,15 +86,14 @@ shared_examples "a resource with JQL inputs and a collection GET endpoint" do
     stub_request(
       :get,
       site_url +
-        client.options[:rest_base_path] +
-        '/search?jql=' +
+        client.options[:rest_base_path_v3] +
+        '/search/jql?jql=' +
         CGI.escape(jql_query_string)
     ).to_return(:status => 200, :body => get_mock_response('issue.json'))
 
     collection = build_receiver.jql(jql_query_string)
-
-    expect(collection.length).to eq(expected_collection_length)
-    expect(collection.first).to have_attributes(expected_attributes)
+    expect(collection["issues"].length).to eq(expected_collection_length)
+    expect(collection["issues"].first).to have_attributes(expected_attributes)
   end
 
 end


### PR DESCRIPTION
Enable the support for v2 search as well, as for some clients using on-prem server for jira, v3 is not yet supported. The client can call `jql_v2` and the gem would hit the v2 search api.